### PR TITLE
Opcua 2527 syntax error missing semicolon after sockstartup

### DIFF
--- a/include/SnmpExceptions.h
+++ b/include/SnmpExceptions.h
@@ -42,6 +42,9 @@ public:
 };
 
 }
+#if defined (_MSC_VER ) // i.e. being compiled by MS vis studio
+  #define __PRETTY_FUNCTION__ __FUNCSIG__ // because MS vis studio has no __PRETTY_FUNCTION__
+#endif
 
 #define snmp_throw_runtime_error_with_origin(MSG) throw std::runtime_error(std::string("At ")+__PRETTY_FUNCTION__+" "+MSG)
 

--- a/src/SnmpBackend.cpp
+++ b/src/SnmpBackend.cpp
@@ -205,7 +205,7 @@ snmp_session SnmpBackend::createSessionV3 ()
 void SnmpBackend::openSession ( snmp_session snmpSession )
 {
 
-	SOCK_STARTUP
+	SOCK_STARTUP;
 
 	try
 	{


### PR DESCRIPTION
details in https://its.cern.ch/jira/browse/OPCUA-2527

another fix needed for windows.

Note this branch was based on the branch created for previous PR
https://github.com/quasar-team/mule/pull/5

So I guess merge PR #5 before this one
