### PR TITLE
Add <cstdint> include

### DIFF
--- a/include/Oid.h
+++ b/include/Oid.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/include/SnmpBackend.h
+++ b/include/SnmpBackend.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <variant>

--- a/include/SnmpStatus.h
+++ b/include/SnmpStatus.h
@@ -29,6 +29,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 namespace Snmp {
 
 enum SnmpStatus : uint32_t


### PR DESCRIPTION
GCC-14 (the version included with Alma 10) is more strict regarding include. From the porting documentation:

```
Some C++ Standard Library headers have been changed to no longer include other headers that were being used internally by the library. As such, C++ programs that used standard library components without including the right headers will no longer compile.

The following headers are used less widely in libstdc++ and may need to be included explicitly when compiling with GCC 14:

<algorithm> (for std::copy_n, std::find_if, std::lower_bound, std::remove, std::reverse, std::sort etc.)
<cstdint> (for std::int8_t, std::int32_t etc.)
```
URL: https://gcc.gnu.org/gcc-14/porting_to.html

It should have zero effect in Alma 9