### PR TITLE
Bump cmake_minimum_required 3.0 -> 3.16 (CMake 4.x compatibility)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@
 
 message(STATUS "Building mule")
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 project(mule CXX)
 
 # C++ standard set

--- a/Demo/CMakeLists.txt
+++ b/Demo/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(MULE_DEMO CXX)
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 add_compile_options( -std=c++17 )
 


### PR DESCRIPTION
## What
Bump `cmake_minimum_required` from 3.0 to 3.16 in the root `CMakeLists.txt` (and 3.10 -> 3.16 in `Demo/CMakeLists.txt` for consistency).

## Why
CMake 4.x **removed support for declared minimums below 3.5**, so the old 3.0 floor is a hard configure failure on recent toolchains (e.g. `tdaq-13-00-00` / CMake 4.3.1) — the same failure mode as OPCUA-3334. 3.16 is the value the quasar framework is standardizing on (>=3.5 for CMake 4.x, <=3.26 for AlmaLinux 9's default CMake), keeping mule consistent with the rest of the ecosystem.

No functional change beyond the minimum; mule already builds on CMake >> 3.16 on all supported platforms.